### PR TITLE
CDC-78 update to organisation icon

### DIFF
--- a/ckan/plugins/ckanext-datacatalogue_theme/ckanext/datacatalogue_theme/templates/snippets/organization_item.html
+++ b/ckan/plugins/ckanext-datacatalogue_theme/ckanext/datacatalogue_theme/templates/snippets/organization_item.html
@@ -1,0 +1,20 @@
+<section class="group-list module module-narrow module-shallow">
+  <header class="module-heading">
+    {% set url=h.url_for(controller='organization', action='read', id=organization.name) %}
+    {% set truncate=truncate or 0 %}
+    <a class="module-image" href="{{ url }}">
+      <img src="{{ organization.image_display_url or h.url_for_static('/images/homeOfficeLogo.png') }}" alt="{{ organization.name }}" />
+    </a>
+    <h3 class="media-heading"><a href={{ url }}>{{ organization.title or organization.name }}</a></h3>
+    {% if organization.description %}
+      {% if truncate == 0 %}
+        <p>{{ h.markdown_extract(organization.description)|urlize }}</p>
+      {% else %}
+        <p>{{ h.markdown_extract(organization.description, truncate)|urlize }}</p>
+      {% endif %}
+    {% endif %}
+  </header>
+  {% set list_class = "unstyled dataset-list" %}
+  {% set item_class = "dataset-item module-content" %}
+  {% snippet 'snippets/package_list.html', packages=organization.packages, list_class=list_class, item_class=item_class, truncate=120 %}
+</section>


### PR DESCRIPTION
The landing page lists recently viewed organisations, this PR introduces a snippet to replace the default image used.

