### PR TITLE
CDC-78 use {% ckan_extends %} in customised snippets

### DIFF
--- a/ckan/plugins/ckanext-datacatalogue_theme/ckanext/datacatalogue_theme/templates/organization/snippets/organization_item.html
+++ b/ckan/plugins/ckanext-datacatalogue_theme/ckanext/datacatalogue_theme/templates/organization/snippets/organization_item.html
@@ -1,33 +1,5 @@
-{% set url = h.url_for(organization.type ~ '_read', action='read', id=organization.name) %}
-{% block item %}
-<li class="media-item">
-  {% block item_inner %}
-  {% block image %}
+{% ckan_extends %}
+
+{% block image %}
     <img src="{{ organization.image_display_url or h.url_for_static('/images/homeOfficeLogo.png') }}" alt="{{ organization.name }}" class="media-image">
-  {% endblock %}
-  {% block title %}
-    <h3 class="media-heading">{{ organization.display_name }}</h3>
-  {% endblock %}
-  {% block description %}
-    {% if organization.description %}
-      <p>{{ h.markdown_extract(organization.description, extract_length=80) }}</p>
-    {% endif %}
-  {% endblock %}
-  {% block datasets %}
-    {% if organization.package_count %}
-      <strong class="count">{{ ungettext('{num} Dataset', '{num} Datasets', organization.package_count).format(num=organization.package_count) }}</strong>
-    {% else %}
-      <span class="count">{{ _('0 Datasets') }}</span>
-    {% endif %}
-  {% endblock %}
-  {% block link %}
-  <a href="{{ url }}" title="{{ _('View {organization_name}').format(organization_name=organization.display_name) }}" class="media-view">
-    <span>{{ _('View {organization_name}').format(organization_name=organization.display_name) }}</span>
-  </a>
-  {% endblock %}
-  {% endblock %}
-</li>
 {% endblock %}
-{% if position is divisibleby 3 %}
-  <li class="clearfix js-hide"></li>
-{% endif %}

--- a/ckan/plugins/ckanext-datacatalogue_theme/ckanext/datacatalogue_theme/templates/snippets/organization.html
+++ b/ckan/plugins/ckanext-datacatalogue_theme/ckanext/datacatalogue_theme/templates/snippets/organization.html
@@ -1,3 +1,5 @@
+{% ckan_extends %}
+
 {% block image %}
     <div class="image">
         <a href="{{ url }}">


### PR DESCRIPTION
- `{% ckan_extends %}` is a customised jinja feature that allows the substitution of `{% blocks %}` within a template
- otherwise the new snippet will replace the entire contents of its namesake