### PR TITLE
CDC-56 hide visibility field & set default to public

### DIFF
--- a/ckan/plugins/ckanext-additional_fields/ckanext/additional_fields/templates/scheming/form_snippets/organization.html
+++ b/ckan/plugins/ckanext-additional_fields/ckanext/additional_fields/templates/scheming/form_snippets/organization.html
@@ -1,0 +1,5 @@
+{% ckan_extends %}
+
+{% block package_metadata_fields_visibility %}
+        <input type="hidden" name="private" value="False"/>
+{% endblock %}


### PR DESCRIPTION
- created new snippet in the `additional_fields` extension that extends a snippet within the `scheming` extension