### PR TITLE
add snippet that overrides navigation bar in Dataset view

### DIFF
--- a/ckan/plugins/ckanext-datacatalogue_theme/ckanext/datacatalogue_theme/templates/package/read_base.html
+++ b/ckan/plugins/ckanext-datacatalogue_theme/ckanext/datacatalogue_theme/templates/package/read_base.html
@@ -1,0 +1,7 @@
+{% ckan_extends %}
+
+{% block content_primary_nav %}
+    {{ h.build_nav_icon('dataset_read', _('Dataset'), id=pkg.name) }}
+    {{ h.build_nav_icon('dataset_groups', _('Groups'), id=pkg.name) }}
+    {{ h.build_nav_icon('dataset_activity', _('Activity Stream'), id=pkg.name) }}
+{% endblock %}


### PR DESCRIPTION
- excluded any reference to the `related` view.