### PR TITLE
removal of option for admin/editors to make datasets public or private

### DIFF
--- a/ckan/plugins/ckanext-datacatalogue_theme/ckanext/datacatalogue_theme/templates/organization/bulk_process.html
+++ b/ckan/plugins/ckanext-datacatalogue_theme/ckanext/datacatalogue_theme/templates/organization/bulk_process.html
@@ -1,0 +1,69 @@
+{% ckan_extends &}
+
+{% block form %}
+{% if c.page.item_count %}
+<form method="POST" data-module="basic-form">
+    <table class="table table-bordered table-header table-hover table-bulk-edit table-edit-hover" data-module="table-selectable-rows">
+        <col width="8">
+        <col width="120">
+        <thead>
+        <tr>
+            <th></th>
+            <th class="table-actions">
+                <div class="btn-group">
+                    <button name="bulk_action.public" value="public" class="btn" type="submit">
+                        <i class="icon-eye-open"></i>
+                        {{ _('Make public') }}
+                    </button>
+                    <button name="bulk_action.private" value="private" class="btn" type="submit">
+                        <i class="icon-eye-close"></i>
+                        {{ _('Make private') }}
+                    </button>
+                </div>
+                <div class="btn-group">
+                    <button name="bulk_action.delete" value="delete" class="btn btn-danger" type="submit">
+                        <i class="icon-remove"></i>
+                        {{ _('Delete') }}
+                    </button>
+                </div>
+            </th>
+        </tr>
+        </thead>
+        <tbody>
+        {% for package in c.packages %}
+        {% set truncate = truncate or 180 %}
+        {% set truncate_title = truncate_title or 80 %}
+        {% set title = package.title or package.name %}
+        {% set notes = h.markdown_extract(package.notes, extract_length=truncate) %}
+        <tr>
+            <td>
+                <input type="checkbox" name="dataset_{{ package.id }}">
+            </td>
+            <td class="context">
+                <a href="{% url_for controller='package', action='edit', id=package.name %}" class="edit pull-right">
+                    {{ _('Edit') }}
+                </a>
+                <h3 class="dataset-heading">
+                    {{ h.link_to(h.truncate(title, truncate_title), h.url_for(controller='package', action='read', id=package.name)) }}
+                    {% if package.get('state', '').startswith('draft') %}
+                    <span class="label label-info">{{ _('Draft') }}</span>
+                    {% elif package.get('state', '').startswith('deleted') %}
+                    <span class="label label-important">{{ _('Deleted') }}</span>
+                    {% endif %}
+                    {% if package.private %}
+                    <span class="label label-important">{{ _('Private') }}</span>
+                    {% endif %}
+                </h3>
+                {% if notes %}
+                <p>{{ notes|urlize }}</p>
+                {% endif %}
+            </td>
+        </tr>
+        {% endfor %}
+        </tbody>
+    </table>
+</form>
+{% else %}
+<p class="empty">{{ _('This organization has no datasets associated to it') }}</p>
+{% endif %}
+{% endblock %}

--- a/ckan/plugins/ckanext-datacatalogue_theme/ckanext/datacatalogue_theme/templates/organization/bulk_process.html
+++ b/ckan/plugins/ckanext-datacatalogue_theme/ckanext/datacatalogue_theme/templates/organization/bulk_process.html
@@ -1,4 +1,4 @@
-{% ckan_extends &}
+{% ckan_extends %}
 
 {% block form %}
 {% if c.page.item_count %}
@@ -10,16 +10,6 @@
         <tr>
             <th></th>
             <th class="table-actions">
-                <div class="btn-group">
-                    <button name="bulk_action.public" value="public" class="btn" type="submit">
-                        <i class="icon-eye-open"></i>
-                        {{ _('Make public') }}
-                    </button>
-                    <button name="bulk_action.private" value="private" class="btn" type="submit">
-                        <i class="icon-eye-close"></i>
-                        {{ _('Make private') }}
-                    </button>
-                </div>
                 <div class="btn-group">
                     <button name="bulk_action.delete" value="delete" class="btn btn-danger" type="submit">
                         <i class="icon-remove"></i>


### PR DESCRIPTION
Buttons were visible from within the `manage organisations` view so these have been removed.